### PR TITLE
bump vulnerable ua-parser-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wsemi",
-  "version": "1.6.22",
+  "version": "1.6.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wsemi",
-      "version": "1.6.22",
+      "version": "1.6.26",
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.1.1",
@@ -18,7 +18,7 @@
         "seamless-scroll-polyfill": "^1.2.4",
         "tesseract.js": "^2.1.5",
         "tippy.js": "^6.3.2",
-        "ua-parser-js": "^0.7.28",
+        "ua-parser-js": "^0.7.30",
         "viewerjs": "^1.10.1",
         "xlsx": "^0.17.2",
         "xss": "^1.0.10"
@@ -14798,9 +14798,9 @@
       "dev": true
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -27851,9 +27851,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "seamless-scroll-polyfill": "^1.2.4",
     "tesseract.js": "^2.1.5",
     "tippy.js": "^6.3.2",
-    "ua-parser-js": "^0.7.28",
+    "ua-parser-js": "^0.7.30",
     "viewerjs": "^1.10.1",
     "xlsx": "^0.17.2",
     "xss": "^1.0.10"


### PR DESCRIPTION
There's a malicious ua-parser-js NPM takeover, this PR bumps ua-parser-js version to the safe 0.7.30.

Security advisory: https://github.com/advisories/GHSA-pjwm-rvh2-c87w
GH thread: faisalman/ua-parser-js#536